### PR TITLE
Add Support For Non-Standard Sized Shulker Boxes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ cloth_version=11.0.99
 modmenu_version=7.0.1
 
 minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.5
+yarn_mappings=1.20.1+build.1
 loader_version=0.14.21
 
 #Fabric api

--- a/src/main/java/com/bvengo/simpleshulkerpreview/ShulkerSizeExt.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/ShulkerSizeExt.java
@@ -1,0 +1,5 @@
+package com.bvengo.simpleshulkerpreview;
+
+public interface ShulkerSizeExt {
+  public int getInvSize();
+}

--- a/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
@@ -43,7 +43,7 @@ public abstract class DrawContextMixin {
 			if(Utils.isObject(stack, RegexGroup.MINECRAFT_BUNDLE)) {
 				positionOptions = config.positionOptionsBundle;
 			}
-			else if(Utils.isObject(stack, RegexGroup.MINECRAFT_SHULKER) && stack.getCount() > 1) {
+			else if(Utils.isShulkerStack(stack) && stack.getCount() > 1) {
 				positionOptions = config.positionOptionsStacked;
 			}
 			else {
@@ -62,7 +62,7 @@ public abstract class DrawContextMixin {
 		}
 
 		// Display itemBar for shulkers (bundles already have a very similar feature)
-		if(config.showFullness && Utils.isObject(stack, RegexGroup.MINECRAFT_SHULKER)) {
+		if(config.showFullness && Utils.isShulkerStack(stack)) {
 			float fullness = Utils.getFullness(stack, config);
 
 			if(fullness > 0.0f) {

--- a/src/main/java/com/bvengo/simpleshulkerpreview/mixin/ShulkerBoxBlockEntityMixin.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/mixin/ShulkerBoxBlockEntityMixin.java
@@ -1,0 +1,20 @@
+package com.bvengo.simpleshulkerpreview.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.bvengo.simpleshulkerpreview.ShulkerSizeExt;
+
+import net.minecraft.block.entity.ShulkerBoxBlockEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.collection.DefaultedList;
+
+@Mixin(ShulkerBoxBlockEntity.class)
+public class ShulkerBoxBlockEntityMixin implements ShulkerSizeExt {
+  @Shadow
+  private DefaultedList<ItemStack> inventory;
+
+  public int getInvSize() {
+    return inventory.size();
+  }
+}

--- a/src/main/resources/simpleshulkerpreview.mixins.json
+++ b/src/main/resources/simpleshulkerpreview.mixins.json
@@ -6,7 +6,8 @@
   "mixins": [
   ],
   "client": [
-    "DrawContextMixin"
+    "DrawContextMixin",
+    "ShulkerBoxBlockEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
I've been playing with the [Reinforced Shulker Boxes Mod](https://modrinth.com/mod/reinforced-shulker-boxes) and was sad to see there were no previews.

This PR addresses that concern with the following changes:

- Adds a mixin to sneakily get a ShulkerBoxBlockEntity's inventory size
- Uses that mixin for determining the size of a shulker box
- Adds a util for checking if an ItemStack's item is a ShulkerBoxBlock's Item to replace the previous Regex check.

Screenshots :)

![image](https://github.com/BVengo/simple-shulker-preview/assets/4142480/906f25da-b2cd-4736-ad24-e46087df6966)
![image](https://github.com/BVengo/simple-shulker-preview/assets/4142480/d467686f-8aaf-4893-b5e5-3acb9d19cade)
