### PR TITLE
Fix for Issue #44: Inaccurate Fill-Level Display

### DIFF
--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
@@ -113,16 +113,16 @@ public class ContainerManager {
             return Fraction.ZERO;
         }
 
-        int maxItems = SimpleShulkerPreviewMod.CONFIGS.shulkerInventoryOptions.getSize() * 64; // Maximum number of items in the shulker
-        int numItems = 0; // Actual number of items in the shulker
+        Fraction maxItems = Fraction.getFraction(SimpleShulkerPreviewMod.CONFIGS.shulkerInventoryOptions.getSize() * 64, 1); // Maximum number of items in the shulker
+        Fraction numItems = Fraction.ZERO; // Actual number of items in the shulker
 
         Iterable<ItemStack> itemIterable = containerComponent.iterateNonEmpty();
         for(ItemStack itemStack : itemIterable) {
-            numItems += itemStack.getCount();
-            maxItems += itemStack.getItem().getMaxCount() - 64; // Replace the previous 64 with the actual max size of the item
+        	numItems = numItems.add(Fraction.getFraction(itemStack.getCount(), itemStack.getItem().getMaxCount()).multiplyBy(Fraction.getFraction(64, 1)));
+ // Adjust by max stack size of item
         }
 
-        return Fraction.getFraction(numItems, maxItems);
+        return numItems.divideBy(maxItems);
     }
 
     private Fraction getBundleCapacity() {

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
@@ -118,8 +118,7 @@ public class ContainerManager {
 
         Iterable<ItemStack> itemIterable = containerComponent.iterateNonEmpty();
         for(ItemStack itemStack : itemIterable) {
-        	numItems = numItems.add(Fraction.getFraction(itemStack.getCount(), itemStack.getItem().getMaxCount()).multiplyBy(Fraction.getFraction(64, 1)));
- // Adjust by max stack size of item
+        	numItems = numItems.add(Fraction.getFraction(itemStack.getCount(), itemStack.getItem().getMaxCount()).multiplyBy(Fraction.getFraction(64, 1))); // Adjust by max stack size of item
         }
 
         return numItems.divideBy(maxItems);


### PR DESCRIPTION
Changed the calculation for ShulkerboxCapacity so it works correctly with unstackables

I tested the build in my own 1.21.4 world and it appears to be working.