### PR TITLE
Add 'Hide If No Icon' capacity bar option

### DIFF
--- a/src/main/java/com/bvengo/simpleshulkerpreview/config/ConfigOptions.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/config/ConfigOptions.java
@@ -46,6 +46,10 @@ public class ConfigOptions implements ConfigData {
     @ConfigEntry.Gui.Tooltip()
     public boolean showCapacity = true;
 
+    /** Hide the capacity bar when no icon is displayed. */
+    @ConfigEntry.Gui.Tooltip()
+    public boolean hideCapacityIfNoIcon = true;
+
     @ConfigEntry.Gui.CollapsibleObject()
     @ConfigEntry.Gui.Tooltip()
     public CapacityBarOptions capacityBarOptions = new CapacityBarOptions();

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
@@ -89,6 +89,10 @@ public class ContainerManager {
         return capacity;
     }
 
+    public boolean isSupported() {
+        return isContainerSupported;
+    }
+
     public ContainerType getContainerType() {
         return containerType;
     }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
@@ -42,10 +42,14 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 
 		ItemStack displayStack = containerParser.getDisplayStack();
 
-		if(displayStack == null) return;
+		if(displayStack == null && (!containerParser.isSupported() || SimpleShulkerPreviewMod.CONFIGS.hideCapacityIfNoIcon)) {
+			return;
+		}
 
-		iconRenderer = new IconRenderer(containerParser, displayStack, x, y);
-		iconRenderer.renderOptional((DrawContext)(Object)this);
+		if(displayStack != null) {
+			iconRenderer = new IconRenderer(containerParser, displayStack, x, y);
+			iconRenderer.renderOptional((DrawContext)(Object)this);
+		}
 
 		// Display itemBar for containers. Ignore bundles - they already have this feature
 		boolean isBundle = containerParser.getContainerType().equals(ContainerType.BUNDLE);

--- a/src/main/resources/assets/simpleshulkerpreview/lang/en_us.json
+++ b/src/main/resources/assets/simpleshulkerpreview/lang/en_us.json
@@ -12,6 +12,8 @@
 	"text.autoconfig.simpleshulkerpreview.option.groupEnchantment.@Tooltip": "Group enchanted items separately from un-enchanted items.",
 	"text.autoconfig.simpleshulkerpreview.option.showCapacity": "Show Capacity",
 	"text.autoconfig.simpleshulkerpreview.option.showCapacity.@Tooltip": "Show the capacity of the shulker box.",
+	"text.autoconfig.simpleshulkerpreview.option.hideCapacityIfNoIcon": "Hide If No Icon",
+	"text.autoconfig.simpleshulkerpreview.option.hideCapacityIfNoIcon.@Tooltip": "Hide the capacity bar when no icon is displayed. Disable to show the capacity bar even for shulkers with mixed items.",
 	"text.autoconfig.simpleshulkerpreview.option.stackSizeOptions": "Stack Size Options",
 	"text.autoconfig.simpleshulkerpreview.option.stackSizeOptions.@Tooltip": "Set the quantity bounds required to display an icon. There must be at least (stack size * stack count) of an item for it to be displayed.",
 	"text.autoconfig.simpleshulkerpreview.option.stackSizeOptions.minStackSize": "Minimum Stack Size",


### PR DESCRIPTION
## Summary

- Adds a new boolean config option **Hide If No Icon** (default: `true`) in the General Settings section, placed directly below "Show Capacity"
- When disabled, the capacity bar will render even when no icon is displayed — useful for players using the **Unique** display mode who still want to see fill level on mixed-item shulkers
- Introduces a public `ContainerManager.isSupported()` method so the mixin can distinguish "not a container" from "container with no qualifying icon"

## Test plan

- [ ] Default behaviour (`hideCapacityIfNoIcon = true`) is unchanged — capacity bar only appears alongside an icon
- [ ] With option disabled and **Display Icon = Unique**, capacity bar appears on shulkers with mixed items even though no icon is shown
- [ ] With option disabled and **Display Icon = First/Last/Most/Least**, behaviour is unchanged (icon always present when container is non-empty)
- [ ] Bundles are unaffected (already excluded from the capacity bar path)
- [ ] Unsupported containers (no `CONTAINER`/`BUNDLE_CONTENTS` component) still render nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)