### PR TITLE
Port of the Simple Shulker Preview to Minecraft 26.1.X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version "${loom_version}"
+	id 'net.fabricmc.fabric-loom' version "${loom_version}"
 	id 'maven-publish'
 }
 
@@ -25,18 +25,18 @@ dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
 
 	// Tells Gradle to use mod menu
-	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}", {
+	implementation "com.terraformersmc:modmenu:${project.modmenu_version}", {
 		exclude module: 'fabric-api'
 	}
 	
 	// Tells Gradle to use cloth config
-	modImplementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}", {
+	implementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}", {
 		exclude module: 'fabric-api'
 	}
 	include "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}"
@@ -51,7 +51,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 21
+	it.options.release = 25
 }
 
 java {
@@ -60,8 +60,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_21
-	targetCompatibility = JavaVersion.VERSION_21
+	sourceCompatibility = JavaVersion.VERSION_25
+	targetCompatibility = JavaVersion.VERSION_25
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 
 # Mod Properties
-mod_version = 2.4.11
+mod_version = 2.5.0
 maven_group = com.bvengo
 archives_base_name = simpleshulkerpreview
 
@@ -12,13 +12,12 @@ archives_base_name = simpleshulkerpreview
 ## https://maven.shedaniel.me/me/shedaniel/cloth/cloth-config-fabric/
 ## https://maven.terraformersmc.com/com/terraformersmc/modmenu
 
-cloth_version=21.11.153
-modmenu_version=17.0.0-beta.1
+cloth_version=26.1.154
+modmenu_version=18.0.0-alpha.8
 
-minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.3
-loader_version=0.18.2
-loom_version=1.14-SNAPSHOT
+minecraft_version=26.1
+loader_version=0.19.2
+loom_version=1.16-SNAPSHOT
 
 # Fabric API
-fabric_version=0.139.4+1.21.11
+fabric_api_version=0.145.1+26.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/bvengo/simpleshulkerpreview/ModMenuIntegration.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/ModMenuIntegration.java
@@ -4,6 +4,7 @@ import com.bvengo.simpleshulkerpreview.config.ConfigOptions;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfigClient;
 
 /**
  * Set up Mod Menu.
@@ -11,6 +12,6 @@ import me.shedaniel.autoconfig.AutoConfig;
 public class ModMenuIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfig.getConfigScreen(ConfigOptions.class, parent).get();
+        return parent -> AutoConfigClient.getConfigScreen(ConfigOptions.class, parent).get();
     }
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/ModMenuIntegration.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/ModMenuIntegration.java
@@ -3,7 +3,6 @@ package com.bvengo.simpleshulkerpreview;
 import com.bvengo.simpleshulkerpreview.config.ConfigOptions;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
-import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.AutoConfigClient;
 
 /**

--- a/src/main/java/com/bvengo/simpleshulkerpreview/config/CapacityDirectionOption.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/config/CapacityDirectionOption.java
@@ -1,7 +1,7 @@
 package com.bvengo.simpleshulkerpreview.config;
 
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
-import net.minecraft.util.Language;
+import net.minecraft.locale.Language;
 
 /** Which direction does the capacity bar fill up in? */
 public enum CapacityDirectionOption {
@@ -12,6 +12,6 @@ public enum CapacityDirectionOption {
 
     @Override
     public String toString() {
-        return Language.getInstance().get("config." + SimpleShulkerPreviewMod.MOD_ID + ".capacityDirection." + this.name().toLowerCase());
+        return Language.getInstance().getOrDefault("config." + SimpleShulkerPreviewMod.MOD_ID + ".capacityDirection." + this.name().toLowerCase());
     }
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/config/CustomNameOption.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/config/CustomNameOption.java
@@ -1,7 +1,7 @@
 package com.bvengo.simpleshulkerpreview.config;
 
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
-import net.minecraft.util.Language;
+import net.minecraft.locale.Language;
 
 /** Shulker box slots that can be displayed */
 public enum CustomNameOption {
@@ -11,6 +11,6 @@ public enum CustomNameOption {
 
     @Override
     public String toString() {
-        return Language.getInstance().get("config." + SimpleShulkerPreviewMod.MOD_ID + ".customName." + this.name().toLowerCase());
+        return Language.getInstance().getOrDefault("config." + SimpleShulkerPreviewMod.MOD_ID + ".customName." + this.name().toLowerCase());
     }
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/config/IconDisplayOption.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/config/IconDisplayOption.java
@@ -1,7 +1,7 @@
 package com.bvengo.simpleshulkerpreview.config;
 
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
-import net.minecraft.util.Language;
+import net.minecraft.locale.Language;
 
 /** Shulker box slots that can be displayed */
 public enum IconDisplayOption {
@@ -13,6 +13,6 @@ public enum IconDisplayOption {
 
     @Override
     public String toString() {
-        return Language.getInstance().get("config." + SimpleShulkerPreviewMod.MOD_ID + ".displayIcon." + this.name().toLowerCase());
+        return Language.getInstance().getOrDefault("config." + SimpleShulkerPreviewMod.MOD_ID + ".displayIcon." + this.name().toLowerCase());
     }
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
@@ -3,17 +3,16 @@ package com.bvengo.simpleshulkerpreview.container;
 
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.config.CustomNameOption;
-
-import net.minecraft.component.ComponentMap;
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.BundleContentsComponent;
-import net.minecraft.component.type.ContainerComponent;
-import net.minecraft.item.ItemStack;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.BundleContents;
+import net.minecraft.world.item.component.ItemContainerContents;
 import org.apache.commons.lang3.math.Fraction;
 
 public class ContainerManager {
     private final ItemStack containerStack;
-    private final ComponentMap containerComponents;
+    private final DataComponentMap containerComponents;
     private final String containerId;
 
     private boolean isContainerSupported;
@@ -23,7 +22,7 @@ public class ContainerManager {
 
     public ContainerManager(ItemStack containerStack) {
         this.containerStack = containerStack;
-        this.containerId = containerStack.getRegistryEntry().getIdAsString();
+        this.containerId = containerStack.getItemHolder().getRegisteredName();
         this.containerComponents = containerStack.getComponents();
         
         setContainerContentsType();
@@ -44,12 +43,12 @@ public class ContainerManager {
         Iterable<ItemStack> itemIterable;
         switch(containerContentsType) {
             case CONTAINER:
-                ContainerComponent containerComponent = containerStack.get(DataComponentTypes.CONTAINER);
-                itemIterable = containerComponent.iterateNonEmptyCopy();
+                ItemContainerContents containerComponent = containerStack.get(DataComponents.CONTAINER);
+                itemIterable = containerComponent.nonEmptyItemsCopy();
                 break;
             case BUNDLE:
-                BundleContentsComponent bundleComponent = containerStack.get(DataComponentTypes.BUNDLE_CONTENTS);
-                itemIterable = bundleComponent.iterateCopy();
+                BundleContents bundleComponent = containerStack.get(DataComponents.BUNDLE_CONTENTS);
+                itemIterable = bundleComponent.itemsCopy();
                 break;
             case NONE:
                 // String badContainerId = containerStack.getRegistryEntry().getIdAsString();
@@ -104,7 +103,7 @@ public class ContainerManager {
     }
 
     private Fraction getShulkerCapacity() {
-        ContainerComponent containerComponent = containerStack.get(DataComponentTypes.CONTAINER);
+        ItemContainerContents containerComponent = containerStack.get(DataComponents.CONTAINER);
         if(containerComponent == null) {
 //            String msg = String.format("Cannot get container component for container '%s'.", containerId);
 //            SimpleShulkerPreviewMod.LOGGER.warn(msg);
@@ -114,7 +113,7 @@ public class ContainerManager {
         Fraction maxItems = Fraction.getFraction(SimpleShulkerPreviewMod.CONFIGS.shulkerInventoryOptions.getSize() * 64, 1); // Maximum number of items in the shulker
         Fraction numItems = Fraction.ZERO; // Actual number of items in the shulker
 
-        Iterable<ItemStack> itemIterable = containerComponent.iterateNonEmpty();
+        Iterable<ItemStack> itemIterable = containerComponent.nonEmptyItems();
         for(ItemStack itemStack : itemIterable) {
         	numItems = numItems.add(ItemStackManager.getItemCountEquivalent(itemStack)); // Adjust by max stack size of item
         }
@@ -123,14 +122,14 @@ public class ContainerManager {
     }
 
     private Fraction getBundleCapacity() {
-        BundleContentsComponent bundleComponent = containerStack.get(DataComponentTypes.BUNDLE_CONTENTS);
-        return bundleComponent.getOccupancy();
+        BundleContents bundleComponent = containerStack.get(DataComponents.BUNDLE_CONTENTS);
+        return bundleComponent.weight();
     }
 
     private void setContainerContentsType() {
-        if(containerComponents.contains(DataComponentTypes.CONTAINER)) {
+        if(containerComponents.has(DataComponents.CONTAINER)) {
             containerContentsType = ContainerContentsType.CONTAINER;
-        } else if(containerComponents.contains(DataComponentTypes.BUNDLE_CONTENTS)) {
+        } else if(containerComponents.has(DataComponents.BUNDLE_CONTENTS)) {
             containerContentsType = ContainerContentsType.BUNDLE;
         } else {
             containerContentsType = ContainerContentsType.NONE;

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ContainerManager.java
@@ -1,6 +1,6 @@
 package com.bvengo.simpleshulkerpreview.container;
 
-
+import java.util.stream.Stream;
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.config.CustomNameOption;
 import net.minecraft.core.component.DataComponentMap;
@@ -22,7 +22,7 @@ public class ContainerManager {
 
     public ContainerManager(ItemStack containerStack) {
         this.containerStack = containerStack;
-        this.containerId = containerStack.getItemHolder().getRegisteredName();
+        this.containerId = containerStack.typeHolder().getRegisteredName();
         this.containerComponents = containerStack.getComponents();
         
         setContainerContentsType();
@@ -44,11 +44,13 @@ public class ContainerManager {
         switch(containerContentsType) {
             case CONTAINER:
                 ItemContainerContents containerComponent = containerStack.get(DataComponents.CONTAINER);
-                itemIterable = containerComponent.nonEmptyItemsCopy();
+                Stream<ItemStack> nonEmptyItemCopyStream = containerComponent.nonEmptyItemCopyStream();
+                itemIterable = () -> nonEmptyItemCopyStream.iterator();
                 break;
             case BUNDLE:
                 BundleContents bundleComponent = containerStack.get(DataComponents.BUNDLE_CONTENTS);
-                itemIterable = bundleComponent.itemsCopy();
+                Stream<ItemStack> itemCopyStream = bundleComponent.itemCopyStream();
+                itemIterable = () -> itemCopyStream.iterator();
                 break;
             case NONE:
                 // String badContainerId = containerStack.getRegistryEntry().getIdAsString();
@@ -113,7 +115,8 @@ public class ContainerManager {
         Fraction maxItems = Fraction.getFraction(SimpleShulkerPreviewMod.CONFIGS.shulkerInventoryOptions.getSize() * 64, 1); // Maximum number of items in the shulker
         Fraction numItems = Fraction.ZERO; // Actual number of items in the shulker
 
-        Iterable<ItemStack> itemIterable = containerComponent.nonEmptyItems();
+        Stream<ItemStack> nonEmptyItemCopyStream = containerComponent.nonEmptyItemCopyStream();
+        Iterable<ItemStack> itemIterable = () -> nonEmptyItemCopyStream.iterator();
         for(ItemStack itemStack : itemIterable) {
         	numItems = numItems.add(ItemStackManager.getItemCountEquivalent(itemStack)); // Adjust by max stack size of item
         }
@@ -123,7 +126,7 @@ public class ContainerManager {
 
     private Fraction getBundleCapacity() {
         BundleContents bundleComponent = containerStack.get(DataComponents.BUNDLE_CONTENTS);
-        return bundleComponent.weight();
+        return bundleComponent.weight().result().get();
     }
 
     private void setContainerContentsType() {

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ItemStackManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ItemStackManager.java
@@ -6,19 +6,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.component.ResolvableProfile;
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.config.CustomNameOption;
-
-import net.minecraft.component.DataComponentTypes;
-import net.minecraft.component.type.PotionContentsComponent;
-import net.minecraft.component.type.ProfileComponent;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.registry.Registries;
-import net.minecraft.text.Text;
-import net.minecraft.util.Identifier;
 import org.apache.commons.lang3.math.Fraction;
 
 public class ItemStackManager {
@@ -32,10 +30,10 @@ public class ItemStackManager {
         }
 
         private void setItemString() {
-            itemString = itemStack.getItem().getTranslationKey();
+            itemString = itemStack.getItem().getDescriptionId();
             
             // Player heads
-            if(itemStack.isOf(Items.PLAYER_HEAD)) {
+            if(itemStack.is(Items.PLAYER_HEAD)) {
                 String skullName = getSkullName(itemStack);
                 if(skullName != null) {
                     itemString += "." + skullName;
@@ -43,7 +41,7 @@ public class ItemStackManager {
             }
 
 			// Potions
-			if(itemStack.isOf(Items.POTION)) {
+			if(itemStack.is(Items.POTION)) {
 				String potionType = getPotionType(itemStack);
 				if(potionType != null) {
 					itemString += "." + potionType;
@@ -51,7 +49,7 @@ public class ItemStackManager {
 			}
 
             // Group enchantments
-            if (SimpleShulkerPreviewMod.CONFIGS.groupEnchantment && itemStack.hasEnchantments()) {
+            if (SimpleShulkerPreviewMod.CONFIGS.groupEnchantment && itemStack.isEnchanted()) {
                 itemString += ".enchanted";
             }
         }
@@ -84,7 +82,7 @@ public class ItemStackManager {
     }
 
     public static Fraction getItemFraction(ItemStack itemStack) {
-        return Fraction.getFraction(itemStack.getCount(), itemStack.getMaxCount());
+        return Fraction.getFraction(itemStack.getCount(), itemStack.getMaxStackSize());
     }
 
     public static Fraction getItemCountEquivalent(ItemStack itemStack) {
@@ -130,14 +128,14 @@ public class ItemStackManager {
     public static ItemStack getItemFromCustomName(ItemStack itemStack) {
         if(SimpleShulkerPreviewMod.CONFIGS.customName == CustomNameOption.NEVER) return null;
 
-        Text customName = itemStack.getComponents().get(DataComponentTypes.CUSTOM_NAME);
+        Component customName = itemStack.getComponents().get(DataComponents.CUSTOM_NAME);
         if(customName == null) return null;
 
         Identifier itemId = Identifier.tryParse(customName.getString());
         // Note: Invalid custom names still return `minecraft:<customName>`, so we need to check the item instead of the ID
         if(itemId == null) return null;
 
-        Item item = Registries.ITEM.get(itemId);
+        Item item = BuiltInRegistries.ITEM.getValue(itemId);
         if(item.equals(Items.AIR)) return null;  // Check for invalid item
 
         return new ItemStack(item);
@@ -150,10 +148,10 @@ public class ItemStackManager {
      * @return A String indicating with the head ID. If missing, returns null.
      */
     private static String getSkullName(ItemStack itemStack) {
-        ProfileComponent profileComponent = itemStack.get(DataComponentTypes.PROFILE);
+        ResolvableProfile profileComponent = itemStack.get(DataComponents.PROFILE);
         if(profileComponent == null) return null;
 
-        return(profileComponent.getName().orElse(null));
+        return(profileComponent.name().orElse(null));
     }
 
 	/**
@@ -163,7 +161,7 @@ public class ItemStackManager {
 	 * @return A String indicating the potion type. If missing, returns null.
 	 */
 	private static String getPotionType(ItemStack itemStack) {
-		PotionContentsComponent potionComponent = itemStack.get(DataComponentTypes.POTION_CONTENTS);
+		PotionContents potionComponent = itemStack.get(DataComponents.POTION_CONTENTS);
 		if(potionComponent == null) return null;
 
 		return potionComponent.getName("").getString();

--- a/src/main/java/com/bvengo/simpleshulkerpreview/container/ItemStackManager.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/container/ItemStackManager.java
@@ -112,10 +112,10 @@ public class ItemStackManager {
 						.filter(entry -> entry.getValue() >= itemThreshold)
 						.findFirst();
 			}
-			case MOST -> groupItemStacks(itemIterable).entrySet().stream()
+			case MOST -> groupedItems.entrySet().stream()
 					.filter(entry -> entry.getValue() >= itemThreshold)
 					.max(Map.Entry.comparingByValue());
-			case LEAST -> groupItemStacks(itemIterable).entrySet().stream()
+			case LEAST -> groupedItems.entrySet().stream()
 					.filter(entry -> entry.getValue() >= itemThreshold)
 					.min(Map.Entry.comparingByValue());
 		};

--- a/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
@@ -8,20 +8,19 @@ import com.bvengo.simpleshulkerpreview.positioners.CapacityBarRenderer;
 import com.bvengo.simpleshulkerpreview.positioners.IconRenderer;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.ScreenRect;
-import net.minecraft.client.gui.render.state.ItemGuiElementRenderState;
-import net.minecraft.client.render.item.KeyedItemRenderState;
-import net.minecraft.item.ItemStack;
-
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.navigation.ScreenRectangle;
+import net.minecraft.client.gui.render.state.GuiItemRenderState;
+import net.minecraft.client.renderer.item.TrackingItemStackRenderState;
+import net.minecraft.world.item.ItemStack;
 import org.joml.Matrix3x2f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(DrawContext.class)
+@Mixin(GuiGraphics.class)
 public abstract class DrawContextMixin implements DrawContextAccess {
 	@Unique IconRenderer iconRenderer;
 	@Unique boolean adjustSize = false;
@@ -31,9 +30,9 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 		adjustSize = newValue;
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/DrawContext;drawItemBar(Lnet/minecraft/item/ItemStack;II)V"),
-			method = "drawStackOverlay(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V")
-	private void renderShulkerItemOverlay(TextRenderer textRenderer, ItemStack stack, int x, int y, String stackCountText, CallbackInfo info) {
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;renderItemBar(Lnet/minecraft/world/item/ItemStack;II)V"),
+			method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V")
+	private void renderShulkerItemOverlay(Font textRenderer, ItemStack stack, int x, int y, String stackCountText, CallbackInfo info) {
 		if(SimpleShulkerPreviewMod.CONFIGS.disableMod) {
 			return;
 		}
@@ -45,33 +44,33 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 		if(displayStack == null) return;
 
 		iconRenderer = new IconRenderer(containerParser, displayStack, x, y);
-		iconRenderer.renderOptional((DrawContext)(Object)this);
+		iconRenderer.renderOptional((GuiGraphics)(Object)this);
 
 		// Display itemBar for containers. Ignore bundles - they already have this feature
 		boolean isBundle = containerParser.getContainerType().equals(ContainerType.BUNDLE);
 		if(SimpleShulkerPreviewMod.CONFIGS.showCapacity && !isBundle) {
 			CapacityBarRenderer capacityBarRenderer = new CapacityBarRenderer(containerParser, stack, x, y);
-			capacityBarRenderer.renderOptional((DrawContext)(Object)this);
+			capacityBarRenderer.renderOptional((GuiGraphics)(Object)this);
 		}
 	}
 
 	/**
 	 * Warps the item rendering to apply scaling and centering based on the icon renderer's settings.
 	 * <p>
-	 * Beyond the {@link DrawContext} class, the following classes/methods are relevant for the rendering process:
+	 * Beyond the {@link GuiGraphics} class, the following classes/methods are relevant for the rendering process:
 	 * <ul>
-	 *   <li>{@link ItemGuiElementRenderState} - Represents the state of the item being rendered, including its position and transformation matrix.</li>
-	 *   <li>{@link net.minecraft.client.gui.render.GuiRenderer#prepareItem(ItemGuiElementRenderState, float, float, int, int)} - Where the quad render state is prepared for rendering the item.</li>
+	 *   <li>{@link GuiItemRenderState} - Represents the state of the item being rendered, including its position and transformation matrix.</li>
+	 *   <li>{@link net.minecraft.client.gui.render.GuiRenderer#submitBlitFromItemAtlas(GuiItemRenderState, float, float, int, int)} - Where the quad render state is prepared for rendering the item.</li>
 	 * </ul>
 	 */
 	@WrapOperation(
-			method = "drawItem(Lnet/minecraft/entity/LivingEntity;Lnet/minecraft/world/World;Lnet/minecraft/item/ItemStack;III)V",
+			method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
 			at = @At(
 					value = "NEW",
-					target = "(Ljava/lang/String;Lorg/joml/Matrix3x2f;Lnet/minecraft/client/render/item/KeyedItemRenderState;IILnet/minecraft/client/gui/ScreenRect;)Lnet/minecraft/client/gui/render/state/ItemGuiElementRenderState;"
+					target = "(Ljava/lang/String;Lorg/joml/Matrix3x2f;Lnet/minecraft/client/renderer/item/TrackingItemStackRenderState;IILnet/minecraft/client/gui/navigation/ScreenRectangle;)Lnet/minecraft/client/gui/render/state/GuiItemRenderState;"
 			)
 	)
-	private ItemGuiElementRenderState wrapDrawItem(String itemName, Matrix3x2f originalMatrix, KeyedItemRenderState state, int x, int y, ScreenRect scissor, Operation<ItemGuiElementRenderState> original) {
+	private GuiItemRenderState wrapDrawItem(String itemName, Matrix3x2f originalMatrix, TrackingItemStackRenderState state, int x, int y, ScreenRectangle scissor, Operation<GuiItemRenderState> original) {
 		if (!adjustSize) {
 			return original.call(itemName, originalMatrix, state, x, y, scissor);
 		}

--- a/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/mixin/DrawContextMixin.java
@@ -9,18 +9,20 @@ import com.bvengo.simpleshulkerpreview.positioners.IconRenderer;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
-import net.minecraft.client.gui.render.state.GuiItemRenderState;
+import net.minecraft.client.gui.render.GuiItemAtlas;
 import net.minecraft.client.renderer.item.TrackingItemStackRenderState;
+import net.minecraft.client.renderer.state.gui.GuiItemRenderState;
 import net.minecraft.world.item.ItemStack;
 import org.joml.Matrix3x2f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(GuiGraphics.class)
+@Mixin(GuiGraphicsExtractor.class)
 public abstract class DrawContextMixin implements DrawContextAccess {
 	@Unique IconRenderer iconRenderer;
 	@Unique boolean adjustSize = false;
@@ -30,8 +32,8 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 		adjustSize = newValue;
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;renderItemBar(Lnet/minecraft/world/item/ItemStack;II)V"),
-			method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V")
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;itemBar(Lnet/minecraft/world/item/ItemStack;II)V"),
+			method = "itemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V")
 	private void renderShulkerItemOverlay(Font textRenderer, ItemStack stack, int x, int y, String stackCountText, CallbackInfo info) {
 		if(SimpleShulkerPreviewMod.CONFIGS.disableMod) {
 			return;
@@ -44,35 +46,35 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 		if(displayStack == null) return;
 
 		iconRenderer = new IconRenderer(containerParser, displayStack, x, y);
-		iconRenderer.renderOptional((GuiGraphics)(Object)this);
+		iconRenderer.renderOptional((GuiGraphicsExtractor)(Object)this);
 
 		// Display itemBar for containers. Ignore bundles - they already have this feature
 		boolean isBundle = containerParser.getContainerType().equals(ContainerType.BUNDLE);
 		if(SimpleShulkerPreviewMod.CONFIGS.showCapacity && !isBundle) {
 			CapacityBarRenderer capacityBarRenderer = new CapacityBarRenderer(containerParser, stack, x, y);
-			capacityBarRenderer.renderOptional((GuiGraphics)(Object)this);
+			capacityBarRenderer.renderOptional((GuiGraphicsExtractor)(Object)this);
 		}
 	}
 
 	/**
 	 * Warps the item rendering to apply scaling and centering based on the icon renderer's settings.
 	 * <p>
-	 * Beyond the {@link GuiGraphics} class, the following classes/methods are relevant for the rendering process:
+	 * Beyond the {@link GuiGraphicsExtractor} class, the following classes/methods are relevant for the rendering process:
 	 * <ul>
 	 *   <li>{@link GuiItemRenderState} - Represents the state of the item being rendered, including its position and transformation matrix.</li>
-	 *   <li>{@link net.minecraft.client.gui.render.GuiRenderer#submitBlitFromItemAtlas(GuiItemRenderState, float, float, int, int)} - Where the quad render state is prepared for rendering the item.</li>
+	 *   <li>{@link net.minecraft.client.gui.render.GuiRenderer#submitBlitFromItemAtlas(GuiItemRenderState, GuiItemAtlas.SlotView)} - Where the quad render state is prepared for rendering the item.</li>
 	 * </ul>
 	 */
 	@WrapOperation(
-			method = "renderItem(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
+			method = "item(Lnet/minecraft/world/entity/LivingEntity;Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;III)V",
 			at = @At(
 					value = "NEW",
-					target = "(Ljava/lang/String;Lorg/joml/Matrix3x2f;Lnet/minecraft/client/renderer/item/TrackingItemStackRenderState;IILnet/minecraft/client/gui/navigation/ScreenRectangle;)Lnet/minecraft/client/gui/render/state/GuiItemRenderState;"
+					target = "(Lorg/joml/Matrix3x2f;Lnet/minecraft/client/renderer/item/TrackingItemStackRenderState;IILnet/minecraft/client/gui/navigation/ScreenRectangle;)Lnet/minecraft/client/renderer/state/gui/GuiItemRenderState;"
 			)
 	)
-	private GuiItemRenderState wrapDrawItem(String itemName, Matrix3x2f originalMatrix, TrackingItemStackRenderState state, int x, int y, ScreenRectangle scissor, Operation<GuiItemRenderState> original) {
+	private GuiItemRenderState wrapDrawItem(Matrix3x2f originalMatrix, TrackingItemStackRenderState state, int x, int y, ScreenRectangle scissor, Operation<GuiItemRenderState> original) {
 		if (!adjustSize) {
-			return original.call(itemName, originalMatrix, state, x, y, scissor);
+			return original.call(originalMatrix, state, x, y, scissor);
 		}
 
 		// Apply scaling
@@ -86,6 +88,6 @@ public abstract class DrawContextMixin implements DrawContextAccess {
 		int newScreenX = (int) ((x + iconRenderer.xOffset + shift) / scale);
 		int newScreenY = (int) ((y + iconRenderer.yOffset + shift) / scale);
 
-		return original.call(itemName, newMatrix, state, newScreenX, newScreenY, scissor);
+		return original.call(newMatrix, state, newScreenX, newScreenY, scissor);
 	}
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/CapacityBarRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/CapacityBarRenderer.java
@@ -3,7 +3,7 @@ package com.bvengo.simpleshulkerpreview.positioners;
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.config.CapacityBarOptions;
 import com.bvengo.simpleshulkerpreview.container.ContainerManager;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.CommonColors;
@@ -90,7 +90,7 @@ public class CapacityBarRenderer extends OverlayRenderer {
         }
     }
 
-    protected void render(GuiGraphics context) {
+    protected void render(GuiGraphicsExtractor context) {
         if(configs.displayShadow) {
             context.fill(RenderPipelines.GUI, xBackgroundStart, yBackgroundStart, xBackgroundEnd, yBackgroundEnd, CommonColors.BLACK);
         }
@@ -99,7 +99,7 @@ public class CapacityBarRenderer extends OverlayRenderer {
         context.fill(RenderPipelines.GUI, xCapacityStart, yCapacityStart, xCapacityEnd, yCapacityEnd, ARGB.opaque(colour));
     }
 
-    public void renderOptional(GuiGraphics context) {
+    public void renderOptional(GuiGraphicsExtractor context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/CapacityBarRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/CapacityBarRenderer.java
@@ -3,18 +3,17 @@ package com.bvengo.simpleshulkerpreview.positioners;
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.config.CapacityBarOptions;
 import com.bvengo.simpleshulkerpreview.container.ContainerManager;
-
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.Colors;
-import net.minecraft.util.math.ColorHelper;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.util.ARGB;
+import net.minecraft.util.CommonColors;
+import net.minecraft.world.item.ItemStack;
 import org.apache.commons.lang3.math.Fraction;
 
 public class CapacityBarRenderer extends OverlayRenderer {
     // Taken from BundleItem.java
-    private static final int FULL_ITEM_BAR_COLOR = ColorHelper.fromFloats(1.0F, 1.0F, 0.33F, 0.33F);
-    private static final int ITEM_BAR_COLOR = ColorHelper.fromFloats(1.0F, 0.44F, 0.53F, 1.0F);
+    private static final int FULL_ITEM_BAR_COLOR = ARGB.colorFromFloat(1.0F, 1.0F, 0.33F, 0.33F);
+    private static final int ITEM_BAR_COLOR = ARGB.colorFromFloat(1.0F, 0.44F, 0.53F, 1.0F);
 
     private Fraction capacity;
 
@@ -91,16 +90,16 @@ public class CapacityBarRenderer extends OverlayRenderer {
         }
     }
 
-    protected void render(DrawContext context) {
+    protected void render(GuiGraphics context) {
         if(configs.displayShadow) {
-            context.fill(RenderPipelines.GUI, xBackgroundStart, yBackgroundStart, xBackgroundEnd, yBackgroundEnd, Colors.BLACK);
+            context.fill(RenderPipelines.GUI, xBackgroundStart, yBackgroundStart, xBackgroundEnd, yBackgroundEnd, CommonColors.BLACK);
         }
 
         int colour = capacity.compareTo(Fraction.ONE) == 0 ? FULL_ITEM_BAR_COLOR : ITEM_BAR_COLOR;
-        context.fill(RenderPipelines.GUI, xCapacityStart, yCapacityStart, xCapacityEnd, yCapacityEnd, ColorHelper.fullAlpha(colour));
+        context.fill(RenderPipelines.GUI, xCapacityStart, yCapacityStart, xCapacityEnd, yCapacityEnd, ARGB.opaque(colour));
     }
 
-    public void renderOptional(DrawContext context) {
+    public void renderOptional(GuiGraphics context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/IconRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/IconRenderer.java
@@ -4,7 +4,7 @@ import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.access.DrawContextAccess;
 import com.bvengo.simpleshulkerpreview.config.IconPositionOptions;
 import com.bvengo.simpleshulkerpreview.container.ContainerManager;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.world.item.ItemStack;
 
 public class IconRenderer extends OverlayRenderer {
@@ -48,13 +48,13 @@ public class IconRenderer extends OverlayRenderer {
         scale = iconPositionOptions.scale;
     }
 
-    protected void render(GuiGraphics context) {
+    protected void render(GuiGraphicsExtractor context) {
         ((DrawContextAccess) context).simple_shulker_preview$setAdjustSize(true);
-        context.renderFakeItem(stack, stackX, stackY);
+        context.fakeItem(stack, stackX, stackY);
         ((DrawContextAccess) context).simple_shulker_preview$setAdjustSize(false);
     }
 
-    public void renderOptional(GuiGraphics context) {
+    public void renderOptional(GuiGraphicsExtractor context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/IconRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/IconRenderer.java
@@ -4,9 +4,8 @@ import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
 import com.bvengo.simpleshulkerpreview.access.DrawContextAccess;
 import com.bvengo.simpleshulkerpreview.config.IconPositionOptions;
 import com.bvengo.simpleshulkerpreview.container.ContainerManager;
-
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.item.ItemStack;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
 
 public class IconRenderer extends OverlayRenderer {
 
@@ -49,13 +48,13 @@ public class IconRenderer extends OverlayRenderer {
         scale = iconPositionOptions.scale;
     }
 
-    protected void render(DrawContext context) {
+    protected void render(GuiGraphics context) {
         ((DrawContextAccess) context).simple_shulker_preview$setAdjustSize(true);
-        context.drawItemWithoutEntity(stack, stackX, stackY);
+        context.renderFakeItem(stack, stackX, stackY);
         ((DrawContextAccess) context).simple_shulker_preview$setAdjustSize(false);
     }
 
-    public void renderOptional(DrawContext context) {
+    public void renderOptional(GuiGraphics context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/OverlayRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/OverlayRenderer.java
@@ -1,6 +1,6 @@
 package com.bvengo.simpleshulkerpreview.positioners;
 
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.world.item.ItemStack;
 
 public abstract class OverlayRenderer {
@@ -16,7 +16,7 @@ public abstract class OverlayRenderer {
         this.stackY = y;
     }
 
-    public void renderOptional(GuiGraphics context) {
+    public void renderOptional(GuiGraphicsExtractor context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);
@@ -25,5 +25,5 @@ public abstract class OverlayRenderer {
 
     protected abstract boolean canDisplay();
     protected abstract void calculatePositions();
-    protected abstract void render(GuiGraphics context);
+    protected abstract void render(GuiGraphicsExtractor context);
 }

--- a/src/main/java/com/bvengo/simpleshulkerpreview/positioners/OverlayRenderer.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/positioners/OverlayRenderer.java
@@ -1,7 +1,7 @@
 package com.bvengo.simpleshulkerpreview.positioners;
 
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.item.ItemStack;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
 
 public abstract class OverlayRenderer {
 
@@ -16,7 +16,7 @@ public abstract class OverlayRenderer {
         this.stackY = y;
     }
 
-    public void renderOptional(DrawContext context) {
+    public void renderOptional(GuiGraphics context) {
         if(canDisplay()) {
             calculatePositions();
             render(context);
@@ -25,5 +25,5 @@ public abstract class OverlayRenderer {
 
     protected abstract boolean canDisplay();
     protected abstract void calculatePositions();
-    protected abstract void render(DrawContext context);
+    protected abstract void render(GuiGraphics context);
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "simpleshulkerpreview",
-  "version": "2.4.11",
+  "version": "2.5.0",
   "icon": "assets/simpleshulkerpreview/icon.png",
   "name": "Simple Shulker Preview",
   "description": "Display a configurable icon indicating the contents of a shulker box, as well as a capacity bar.",
@@ -19,9 +19,9 @@
   },
   "mixins": ["simpleshulkerpreview.mixins.json"],
   "depends": {
-    "fabricloader": ">=0.16.0",
-    "minecraft": ">=1.21.11",
-    "java": ">=21",
+    "fabricloader": ">=0.19.2",
+    "minecraft": ">=26.1",
+    "java": ">=25",
     "fabric-api": "*"
   },
   "recommends": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,7 +19,7 @@
   },
   "mixins": ["simpleshulkerpreview.mixins.json"],
   "depends": {
-    "fabricloader": ">=0.19.2",
+    "fabricloader": ">=0.18.4",
     "minecraft": ">=26.1",
     "java": ">=25",
     "fabric-api": "*"

--- a/src/main/resources/simpleshulkerpreview.mixins.json
+++ b/src/main/resources/simpleshulkerpreview.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "com.bvengo.simpleshulkerpreview.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "client": [
     "DrawContextMixin"
   ],


### PR DESCRIPTION
This Pull Request provides a finished port of Simple Shulker Preview to Minecraft 26.1.x.

The main changes include moving from yarn mappings to the official Mojang mappings, bumping all the required versions and fixing various errors caused by upstream code changes.

Huge thanks to @mnowak32 for fixing all the errors related to `GuiGraphics` and `Autoconfig`! (See [pull request](https://github.com/MordorsElite/simple-shulker-preview/pull/1))

The Fork builds successfully and I have tested it in Minecraft 26.1, 26.1.1 and 26.1.2. I've also tested it with both Fabric Loader version 0.18.4 and 0.19.2. Additionally I also ensured that any fabric-API mod version compatible with 26.1 is compatible with the updated mod. So anyone using modded 26.1 should be able to just slot the ported mod in immediately.