### PR TITLE
Fix nested config options silently resetting to defaults

### DIFF
--- a/src/main/java/com/bvengo/simpleshulkerpreview/config/ConfigOptions.java
+++ b/src/main/java/com/bvengo/simpleshulkerpreview/config/ConfigOptions.java
@@ -1,6 +1,7 @@
 package com.bvengo.simpleshulkerpreview.config;
 
 import com.bvengo.simpleshulkerpreview.SimpleShulkerPreviewMod;
+import com.google.gson.FieldNamingPolicy;
 import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
@@ -12,6 +13,10 @@ public class ConfigOptions {
             .id(Identifier.tryParse(SimpleShulkerPreviewMod.MOD_ID + ":config"))
             .serializer(config -> GsonConfigSerializerBuilder.create(config)
                     .setPath(FabricLoader.getInstance().getConfigDir().resolve("simpleshulkerpreview.json"))
+                    // YACL resolves top-level keys itself by field name, but hands nested objects
+                    // straight to Gson, whose default naming policy is LOWER_CASE_WITH_UNDERSCORES.
+                    // Without this, every nested setting silently falls back to its default.
+                    .appendGsonBuilder(builder -> builder.setFieldNamingPolicy(FieldNamingPolicy.IDENTITY))
                     .build())
             .build();
 


### PR DESCRIPTION
### Problem

Every nested config object falls back to its constructor defaults on load —
`capacityBarOptions`, all three `iconPositionOptions*` blocks,
`stackSizeOptions`, `shulkerInventoryOptions`. Top-level options load fine,
so the config looks like it mostly worked.

This hits everyone upgrading from 2.5.0, whose config was written by
autoconfig.

### Cause

`GsonConfigSerializer` builds its Gson with
`FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES`.

YACL resolves top-level keys itself by field name, so those match. Nested
objects instead go through `gson.fromJson(element, access.type())`, where
the naming policy applies — Gson looks for `hide_when_full`, the file has
`hideWhenFull`, nothing matches, and so the field keeps its default. Unknown
keys aren't an error in Gson, so the load reports success (silently errors).

Verified in isolation against YACL 3.9.6: with camelCase keys
`hideWhenFull` reads `false`, with `hide_when_full` it reads `true`.

### Fix

Use the exact field names for nested objects too:

```java
.appendGsonBuilder(builder -> builder.setFieldNamingPolicy(FieldNamingPolicy.IDENTITY))
```

This matches the top-level keys YACL already writes and the pre-YACL config
format, so existing settings survive the upgrade.

### Timing

Worth merging before the 26.2 release IMO.
